### PR TITLE
Prevent unwanted SSL Errors [CERTIFICATE_VERIFY_FAILED] in validate-urls

### DIFF
--- a/.pre-commit-config-weekly.yaml
+++ b/.pre-commit-config-weekly.yaml
@@ -15,4 +15,4 @@ repos:
     entry: python scripts/validate-urls.py
     language: python
     types: [jupyter]
-    additional_dependencies: [nbformat, requests]
+    additional_dependencies: [nbformat, requests, pip-system-certs]


### PR DESCRIPTION
### Description
Our company firewall causes a lot of SSL Errors due to self-signed certificates, even when ostensibly set up correctly. I usually install the [pip-system-certs](https://pypi.org/project/pip-system-certs/) package which silently fixes the issue. However, this only works when installed into the current venv.

This PR adds pip-system-certs to the requirements for [validate-urls](https://github.com/ecmwf-projects/c3s2-eqc-quality-assessment/blob/main/scripts/validate-urls.py) to prevent these SSL Errors in its output (e.g. when running `make qa`), which are not informative and hide any actual problems.

### Examples
I'm using `.pre-commit-config-weekly` as a shortcut for the validate-urls part of `make qa` here.

#### Current
```console
pre-commit run -c .pre-commit-config-weekly.yaml --file templates/template.ipynb

validate-filenames...................................(no files to check)Skipped
validate-urls............................................................Failed
- hook id: validate-urls
- exit code: 1

Traceback (most recent call last):
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 79, in <module>
    main(args.paths)
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 72, in main
    validate_urls(path)
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 62, in validate_urls
    raise RuntimeError(
RuntimeError: Invalid URLs in path=templates/template.ipynb

url='https://api.crossref.org/works/10.1038/s41598-018-20628-2'
HTTPSConnectionPool(host='api.crossref.org', port=443): Max retries exceeded with url: /works/10.1038/s41598-018-20628-2 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)')))

url='https://www.bopen.eu/'
HTTPSConnectionPool(host='www.bopen.eu', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)')))
```

Example with actual URL issues (added a known 404 page to the template):
```console
pre-commit run -c .pre-commit-config-weekly.yaml --file templates/template.ipynb
validate-filenames...................................(no files to check)Skipped
validate-urls............................................................Failed
- hook id: validate-urls
- exit code: 1

Traceback (most recent call last):
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 79, in <module>
    main(args.paths)
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 72, in main
    validate_urls(path)
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 62, in validate_urls
    raise RuntimeError(
RuntimeError: Invalid URLs in path=templates/template.ipynb

url='https://api.crossref.org/works/123'
HTTPSConnectionPool(host='api.crossref.org', port=443): Max retries exceeded with url: /works/123 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)')))

url='https://api.crossref.org/works/10.1038/s41598-018-20628-2'
HTTPSConnectionPool(host='api.crossref.org', port=443): Max retries exceeded with url: /works/10.1038/s41598-018-20628-2 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)')))

url='https://www.bopen.eu/'
HTTPSConnectionPool(host='www.bopen.eu', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)')))
```

#### Suggested
```console
pre-commit run -c .pre-commit-config-weekly.yaml --file templates/template.ipynb

validate-filenames...................................(no files to check)Skipped
validate-urls............................................................Passed
```

Example with actual URL issues (added a known 404 page to the template):
```console
pre-commit run -c .pre-commit-config-weekly.yaml --file templates/template.ipynb

validate-filenames...................................(no files to check)Skipped
validate-urls............................................................Failed
- hook id: validate-urls
- exit code: 1

Traceback (most recent call last):
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 79, in <module>
    main(args.paths)
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 72, in main
    validate_urls(path)
  File "/home/o/git/c3s2-eqc-quality-assessment/scripts/validate-urls.py", line 62, in validate_urls
    raise RuntimeError(
RuntimeError: Invalid URLs in path=templates/template.ipynb

url='https://api.crossref.org/works/123/agency'
404 Client Error: Not Found for url: https://api.crossref.org/works/123/agency
```