### PR TITLE
Fix ruff issues in remove_stderr.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   rev: v2.3.0
   hooks:
   - id: mypy
-    args: [--strict, --ignore-missing-imports]
+    args: [--strict, --ignore-missing-imports, --no-warn-return-any]
     additional_dependencies: [types-requests]
 - repo: local
   hooks:

--- a/scripts/remove_stderr.py
+++ b/scripts/remove_stderr.py
@@ -5,12 +5,12 @@ import nbformat
 
 
 def is_stderr(output: nbformat.notebooknode.NotebookNode) -> bool:
-    """ Check if an output is an stderr. """
-    return (output.output_type == "stream" and output.name == "stderr")
+    """Check if an output is an stderr."""
+    return output.output_type == "stream" and output.name == "stderr"
 
 
 def remove_stderr(notebook: nbformat.notebooknode.NotebookNode) -> None:
-    """ Go through all cells in a notebook and, where relevant, remove stderr outputs. Edits the notebook in-place. """
+    """Go through all cells in a notebook and remove stderr outputs in-place."""
     for cell in notebook.cells:
         # Skip markdown cells
         if cell["cell_type"] != "code":
@@ -21,7 +21,7 @@ def remove_stderr(notebook: nbformat.notebooknode.NotebookNode) -> None:
 
 
 def remove_stderr_file(path: Path | str) -> None:
-    """ Open a file, remove stderr outputs, overwrite original. """
+    """Open a file, remove stderr outputs, overwrite original."""
     # Read file
     notebook = nbformat.read(path, nbformat.NO_CONVERT)
 
@@ -33,7 +33,7 @@ def remove_stderr_file(path: Path | str) -> None:
 
 
 def main(paths: list[Path]) -> None:
-    """ Apply remove_stderr_file to all files. """
+    """Apply remove_stderr_file to all files."""
     for path in paths:
         remove_stderr_file(path)
 


### PR DESCRIPTION
Fixes ruff issues stemming from #632.

@malmans2 this also adds the `--no-warn-return-any` flag to the `mypy` check in `pre-commit`, which was raising false positive errors for this script (python/mypy#5697). This doesn't affect any of the other scripts so should be fine.