### PR TITLE
validate-urls: Allow brackets, Check unique URLs, Verbose option

### DIFF
--- a/scripts/remove_stderr.py
+++ b/scripts/remove_stderr.py
@@ -4,12 +4,12 @@ from pathlib import Path
 import nbformat
 
 
-def is_stderr(output: nbformat.notebooknode.NotebookNode) -> bool:
+def is_stderr(output: nbformat.NotebookNode) -> bool:
     """Check if an output is an stderr."""
     return output.output_type == "stream" and output.name == "stderr"
 
 
-def remove_stderr(notebook: nbformat.notebooknode.NotebookNode) -> None:
+def remove_stderr(notebook: nbformat.NotebookNode) -> None:
     """Go through all cells in a notebook and remove stderr outputs in-place."""
     for cell in notebook.cells:
         # Skip markdown cells

--- a/scripts/validate-urls.py
+++ b/scripts/validate-urls.py
@@ -76,8 +76,14 @@ def validate_urls(path: Path, *, verbose: bool = False) -> None:
                 response.raise_for_status()
 
             except requests.exceptions.SSLError as exc:
+                if verbose:
+                    print("    ->", "SSLError")
+
                 if not url.startswith(KNOWN_SSL_ISSUES):
                     exceptions[url] = exc
+                else:
+                    if verbose:
+                        print("    ->", "Known SSL issue, allowing exception.")
 
             except Exception as exc:
                 exceptions[url] = exc

--- a/scripts/validate-urls.py
+++ b/scripts/validate-urls.py
@@ -33,60 +33,68 @@ CROSSREF_URL = "https://api.crossref.org/works/"
 URL_PATTERN = r"https?://(?:[^\s()]+|\([^\s()]*\))+"  # Allow pairs of brackets in link
 
 
+def find_urls(notebook: nbformat.NotebookNode) -> list[str]:
+    """Find all unique URLs in the given notebook."""
+    markdown_cells = [
+        cell for cell in notebook.cells if cell["cell_type"] == "markdown"
+    ]
+    unique_urls = {
+        url
+        for cell in markdown_cells
+        for url in re.findall(URL_PATTERN, cell.get("source", ""))
+    }
+    return sorted(unique_urls)
+
+
 def validate_urls(path: Path, *, verbose: bool = False) -> None:
     notebook = nbformat.read(path, nbformat.NO_CONVERT)
 
     exceptions: dict[str, Exception] = {}
-    for cell in notebook.cells:
-        if cell["cell_type"] != "markdown":
-            continue
+    for url in find_urls(notebook):
+        if verbose:
+            url_orig = url  # Copy so can be reused later
+            print(url)
 
-        source = cell.get("source", "")
-        for url in set(re.findall(URL_PATTERN, source)):
+        url = url.replace("https://doi.org/", CROSSREF_URL)
+        if verbose:
+            if url != url_orig:  # If url has been changed
+                print("    ->", url)
+
+        try:
+            response = requests.head(url, allow_redirects=True)
+            match response.status_code:
+                case 403:
+                    response = requests.head(
+                        url,
+                        allow_redirects=True,
+                        headers={"User-Agent": USER_AGENT},
+                    )
+                case 404 | 405:
+                    if url.startswith(CROSSREF_URL):
+                        url = url.rstrip("/") + "/agency"
+                    response = requests.get(url, allow_redirects=True)
+
             if verbose:
-                url_orig = url  # Copy so can be reused later
-                print(url)
+                print("    ->", response.status_code)
 
-            url = url.replace("https://doi.org/", CROSSREF_URL)
+            if response.status_code == 429 or (
+                response.status_code == 403 and url.startswith(KNOWN_403_ISSUES)
+            ):
+                continue
+            response.raise_for_status()
+
+        except requests.exceptions.SSLError as exc:
             if verbose:
-                if url != url_orig:  # If url has been changed
-                    print("    ->", url)
+                print("    ->", "SSLError")
 
-            try:
-                response = requests.head(url, allow_redirects=True)
-                match response.status_code:
-                    case 403:
-                        response = requests.head(
-                            url,
-                            allow_redirects=True,
-                            headers={"User-Agent": USER_AGENT},
-                        )
-                    case 404 | 405:
-                        if url.startswith(CROSSREF_URL):
-                            url = url.rstrip("/") + "/agency"
-                        response = requests.get(url, allow_redirects=True)
-
-                if verbose:
-                    print("    ->", response.status_code)
-
-                if response.status_code == 429 or (
-                    response.status_code == 403 and url.startswith(KNOWN_403_ISSUES)
-                ):
-                    continue
-                response.raise_for_status()
-
-            except requests.exceptions.SSLError as exc:
-                if verbose:
-                    print("    ->", "SSLError")
-
-                if not url.startswith(KNOWN_SSL_ISSUES):
-                    exceptions[url] = exc
-                else:
-                    if verbose:
-                        print("    ->", "Known SSL issue, allowing exception.")
-
-            except Exception as exc:
+            if not url.startswith(KNOWN_SSL_ISSUES):
                 exceptions[url] = exc
+            else:
+                if verbose:
+                    print("    ->", "Known SSL issue, allowing exception.")
+
+        except Exception as exc:
+            exceptions[url] = exc
 
     if exceptions:
         raise RuntimeError(

--- a/scripts/validate-urls.py
+++ b/scripts/validate-urls.py
@@ -15,12 +15,12 @@ USER_AGENT = (
 )
 
 KNOWN_SSL_ISSUES = (
-    "https://www.cnr.it",
-    "https://hermes.acri.fr",
-    "https://alt-perubolivia.org",
     "https://apps.climate.copernicus.eu",
     "https://pulse.climate.copernicus.eu",
     "https://thermaltrace.climate.copernicus.eu",
+    "https://www.cnr.it",
+    "https://hermes.acri.fr",
+    "https://alt-perubolivia.org",
     "https://web.unisa.it",
 )
 
@@ -30,10 +30,10 @@ KNOWN_403_ISSUES = (
 )
 
 CROSSREF_URL = "https://api.crossref.org/works/"
-URL_PATTERN = r"https?://[^\s)]+"
+URL_PATTERN = r"https?://(?:[^\s()]+|\([^\s()]*\))+"  # Allow pairs of brackets in link
 
 
-def validate_urls(path: Path) -> None:
+def validate_urls(path: Path, *, verbose: bool = False) -> None:
     notebook = nbformat.read(path, nbformat.NO_CONVERT)
 
     exceptions: dict[str, Exception] = {}
@@ -43,7 +43,15 @@ def validate_urls(path: Path) -> None:
 
         source = cell.get("source", "")
         for url in set(re.findall(URL_PATTERN, source)):
+            if verbose:
+                url_orig = url  # Copy so can be reused later
+                print(url)
+
             url = url.replace("https://doi.org/", CROSSREF_URL)
+            if verbose:
+                if url != url_orig:  # If url has been changed
+                    print("    ->", url)
+
             try:
                 response = requests.head(url, allow_redirects=True)
                 match response.status_code:
@@ -57,14 +65,20 @@ def validate_urls(path: Path) -> None:
                         if url.startswith(CROSSREF_URL):
                             url = url.rstrip("/") + "/agency"
                         response = requests.get(url, allow_redirects=True)
+
+                if verbose:
+                    print("    ->", response.status_code)
+
                 if response.status_code == 429 or (
                     response.status_code == 403 and url.startswith(KNOWN_403_ISSUES)
                 ):
                     continue
                 response.raise_for_status()
+
             except requests.exceptions.SSLError as exc:
                 if not url.startswith(KNOWN_SSL_ISSUES):
                     exceptions[url] = exc
+
             except Exception as exc:
                 exceptions[url] = exc
 
@@ -75,15 +89,23 @@ def validate_urls(path: Path) -> None:
                 + [f"{url=}\n{exc!s}" for url, exc in exceptions.items()]
             )
         )
+    else:  # No exceptions
+        if verbose:
+            print("--- No errors found ✓ ---")
 
 
-def main(paths: list[Path]) -> None:
+def main(paths: list[Path], verbose: bool = False) -> None:
     for path in paths:
-        validate_urls(path)
+        if verbose:
+            print("\n---", path, "---")
+        validate_urls(path, verbose=verbose)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("paths", action="store", type=Path, nargs="*")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Print URLs as they are checked."
+    )
     args = parser.parse_args()
-    main(args.paths)
+    main(args.paths, verbose=args.verbose)


### PR DESCRIPTION
Three improvements to `scripts/validate-urls.py`:
* Allow brackets in URLs by replacing the regex. Removes the need to modify notebooks (e.g. #407, #564) to replace `(` by `%28` and so on.
* Add a verbose option `-v` to print each URL and its status. Not enabled by default in pre-commit but convenient for command-line testing.
* For each notebook, find all unique URLs beforehand rather than going cell-by-cell. Prevents duplicate requests, in some cases speeding up the check by more than 2x per notebook.

Example where I added `https://doi.org/10.1061/(ASCE)0733-9496(2006)132:3(164)`, which previously became `https://api.crossref.org/works/10.1061/(ASCE/agency`, to an existing notebook, with the verbose flag enabled:

```
python scripts/validate-urls.py Derived_Datasets/*.ipynb -v

--- Derived_Datasets/derived_multi-origin-c3s-atlas_consistency_q01.ipynb ---
https://atlas.climate.copernicus.eu/
    -> 200
https://atlas.climate.copernicus.eu/atlas
    -> 200
https://atlas.climate.copernicus.eu/atlas/YNZ3InLU
    -> 200
https://cds.climate.copernicus.eu/how-to-api
    -> 200
https://cds.climate.copernicus.eu/how-to-api#linux-use-client-step
    -> 200
https://confluence.ecmwf.int/display/CKB/Gridded+data+underpinning+the+Copernicus+Interactive+Climate+Atlas%3A+Description+of+the+datasets+and+variables
    -> 200
https://doi.org/10.1016/j.wace.2015.06.003
    -> https://api.crossref.org/works/10.1016/j.wace.2015.06.003
    -> 200
https://doi.org/10.1017/9781009157896.021
    -> https://api.crossref.org/works/10.1017/9781009157896.021
    -> 200
https://doi.org/10.1038/s41597-022-01739-y
    -> https://api.crossref.org/works/10.1038/s41597-022-01739-y
    -> 200
https://doi.org/10.1061/(ASCE)0733-9496(2006)132:3(164)
    -> https://api.crossref.org/works/10.1061/(ASCE)0733-9496(2006)132:3(164)
    -> 200
...
https://www.ecmwf.int/en/newsletter/179/news/copernicus-interactive-climate-atlas-new-tool-visualise-climate-variability
    -> 200
https://xclim.readthedocs.io/en/stable/
    -> 200
--- No errors found ✓ ---
```

I've tested it on existing notebooks and not found any errors that weren't there before (e.g. flaky URLs).