### PR TITLE
validate-urls: Avoid duplicate checks, Avoid early crashes, Cleaner output

### DIFF
--- a/scripts/validate-urls.py
+++ b/scripts/validate-urls.py
@@ -110,32 +110,49 @@ def validate_url(url: str, *, verbose: bool = False) -> Exception | None:
         return result
 
 
-def validate_urls(path: Path, *, verbose: bool = False) -> None:
-    notebook = nbformat.read(path, nbformat.NO_CONVERT)
+def main(paths: list[Path], verbose: bool = False) -> None:
+    # Setup
+    if verbose:
+        print("Testing notebooks:")
+        print("\n".join(f"    {path}" for path in paths))
 
-    # Process all unique URLs, remove Nones
-    exceptions = {
-        url: validate_url(url, verbose=verbose) for url in find_urls(notebook)
+    # Find all unique URLs in all notebooks
+    urls_by_notebook = {
+        path: find_urls(nbformat.read(path, nbformat.NO_CONVERT)) for path in paths
     }
-    exceptions = {url: exc for url, exc in exceptions.items() if exc}
-
-    if exceptions:
-        raise RuntimeError(
-            "\n\n".join(
-                [f"Invalid URLs in {path=!s}"]
-                + [f"{url=}\n{exc!s}" for url, exc in exceptions.items()]
-            )
+    unique_urls = sorted(
+        {url for path, url_list in urls_by_notebook.items() for url in url_list}
+    )
+    notebooks_by_url = {
+        url: sorted(
+            path for path, url_list in urls_by_notebook.items() if url in url_list
         )
+        for url in unique_urls
+    }
+
+    # Check each unique URL
+    url_checks = {url: validate_url(url, verbose=verbose) for url in unique_urls}
+
+    # Output: Raise error describing failing URLs
+    url_has_errors = {
+        url: check for url, check in url_checks.items() if check is not None
+    }
+
+    if url_has_errors:
+        raise RuntimeError(
+            "\n\n"
+            + "\n\n".join(
+                "\n".join(
+                    [f"Failing URL: {url}", "  Occurring in notebooks:"]
+                    + [f"    {path}" for path in notebooks_by_url[url]]
+                    + ["  Error:", f"    {exc!s}"]
+                )
+                for url, exc in url_has_errors.items()
+            )
+        ) from None
     else:  # No exceptions
         if verbose:
-            print("--- No errors found ✓ ---")
-
-
-def main(paths: list[Path], verbose: bool = False) -> None:
-    for path in paths:
-        if verbose:
-            print("\n---", path, "---")
-        validate_urls(path, verbose=verbose)
+            print("--- All URLs pass ✓ ---")
 
 
 if __name__ == "__main__":

--- a/scripts/validate-urls.py
+++ b/scripts/validate-urls.py
@@ -29,6 +29,7 @@ KNOWN_403_ISSUES = (
     "https://web.unisa.it",
 )
 
+ARROW = "    ->"
 CROSSREF_URL = "https://api.crossref.org/works/"
 URL_PATTERN = r"https?://(?:[^\s()]+|\([^\s()]*\))+"  # Allow pairs of brackets in link
 
@@ -46,55 +47,77 @@ def find_urls(notebook: nbformat.NotebookNode) -> list[str]:
     return sorted(unique_urls)
 
 
+def validate_url(url: str, *, verbose: bool = False) -> Exception | None:
+    """Validate a single URL, checking for HTTP status and SSL errors."""
+    result: Exception | requests.exceptions.SSLError | None
+    if verbose:
+        url_orig = url  # Copy so can be reused later
+        print(url)
+
+    url = url.replace("https://doi.org/", CROSSREF_URL)
+    if verbose:
+        if url != url_orig:  # If url has been changed
+            print(ARROW, url)
+
+    try:
+        response = requests.head(url, allow_redirects=True)
+        match response.status_code:
+            case 403:
+                response = requests.head(
+                    url,
+                    allow_redirects=True,
+                    headers={"User-Agent": USER_AGENT},
+                )
+            case 404 | 405:
+                if url.startswith(CROSSREF_URL):
+                    url = url.rstrip("/") + "/agency"
+                response = requests.get(url, allow_redirects=True)
+
+        if verbose:
+            print(ARROW, response.status_code)
+
+        if response.status_code == 429 or (
+            response.status_code == 403 and url.startswith(KNOWN_403_ISSUES)
+        ):
+            if verbose:
+                print(
+                    ARROW,
+                    "Too many requests (429) or known forbidden (403) page, allowing exception.",
+                )
+
+        # Raise Exception corresponding to HTTP status
+        response.raise_for_status()
+
+    except requests.exceptions.SSLError as exc:
+        result = exc
+        if verbose:
+            print(ARROW, "SSLError")
+
+        if url.startswith(KNOWN_SSL_ISSUES):
+            result = None
+            if verbose:
+                print(ARROW, "Known SSL issue, allowing exception.")
+
+    except Exception as exc:
+        result = exc
+        if verbose:
+            print(ARROW, exc)
+
+    else:
+        result = None
+
+    finally:
+        return result
+
+
 def validate_urls(path: Path, *, verbose: bool = False) -> None:
     notebook = nbformat.read(path, nbformat.NO_CONVERT)
 
-    exceptions: dict[str, Exception] = {}
-    for url in find_urls(notebook):
-        if verbose:
-            url_orig = url  # Copy so can be reused later
-            print(url)
-
-        url = url.replace("https://doi.org/", CROSSREF_URL)
-        if verbose:
-            if url != url_orig:  # If url has been changed
-                print("    ->", url)
-
-        try:
-            response = requests.head(url, allow_redirects=True)
-            match response.status_code:
-                case 403:
-                    response = requests.head(
-                        url,
-                        allow_redirects=True,
-                        headers={"User-Agent": USER_AGENT},
-                    )
-                case 404 | 405:
-                    if url.startswith(CROSSREF_URL):
-                        url = url.rstrip("/") + "/agency"
-                    response = requests.get(url, allow_redirects=True)
-
-            if verbose:
-                print("    ->", response.status_code)
-
-            if response.status_code == 429 or (
-                response.status_code == 403 and url.startswith(KNOWN_403_ISSUES)
-            ):
-                continue
-            response.raise_for_status()
-
-        except requests.exceptions.SSLError as exc:
-            if verbose:
-                print("    ->", "SSLError")
-
-            if not url.startswith(KNOWN_SSL_ISSUES):
-                exceptions[url] = exc
-            else:
-                if verbose:
-                    print("    ->", "Known SSL issue, allowing exception.")
-
-        except Exception as exc:
-            exceptions[url] = exc
+    # Process all unique URLs, remove Nones
+    exceptions = {
+        url: validate_url(url, verbose=verbose) for url in find_urls(notebook)
+    }
+    exceptions = {url: exc for url, exc in exceptions.items() if exc}
 
     if exceptions:
         raise RuntimeError(


### PR DESCRIPTION
Follow-up on #636, #407.

Changes the logic of `scripts/validate-urls.py` to first look for all unique URLs, then check each only once, rather than looping over each notebook and checking some URLs (like www.bopen.eu) many times.

Only crashes at the end, rather than after the first notebook with failing URLs, so that all information is provided at once.

Outputs are sorted by URL, e.g.:
```
RuntimeError:

Failing URL: https://www.dailymail.co.uk/news/article-8784073/How-La-Nina-weather-event-decade-bring-wet-summer.html
  Occurring in notebooks:
    Applications/application_climate-pulse_extreme-events_q01.ipynb
  Error:
    503 Server Error: Service Unavailable for url: https://www.dailymail.com/news/article-8784073/How-La-Nina-weather-event-decade-bring-wet-summer.html

Failing URL: https://www.metoffice.gov.uk/binaries/content/assets/metofficegovuk/pdf/business/public-sector/civil-contingency/3moutlook_jja_v2.pdf
  Occurring in notebooks:
    Seasonal_Forecasts/seasonal_seasonal-monthly-single-levels_forecast-skill_q04.ipynb
  Error:
    404 Client Error: Not Found for url: https://www.metoffice.gov.uk/binaries/content/assets/metofficegovuk/pdf/business/public-sector/civil-contingency/3moutlook_jja_v2.pdf
```

This will be useful both for running the script locally and for the [weekly checks](https://github.com/ecmwf-projects/c3s2-eqc-quality-assessment/actions/workflows/weekly.yml).