### PR TITLE
allow 403 for article

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -31,4 +31,5 @@ jobs:
       with:
         title: pre-commit autoupdate
     - uses: pre-commit/action@v3.0.1
+      timeout-minutes: 60
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,14 @@ addopts = [
   "--check-links-ignore=^(?!https?://)|^https?://doi\\.org/",
   "--check-links-cache",
   "--check-links-cache-expire-after=86400",
-  "--check-links-cache-backend-opt=allowable_codes:[200]",
+  "--check-links-cache-backend-opt=allowable_codes:[200,403]",
   # Known 403s
   "--check-links-ignore=https://www.volkskrant.nl/wetenschap/~b301f81f2/",
   "--check-links-ignore=https://glisa.umich.edu/lake-superior-retrospective/",
   "--check-links-ignore=https://psycnet.apa.org/record/1948-15040-000",
   "--check-links-ignore=https://sealevel.nasa.gov/understanding-sea-level/global-sea-level/overview/",
-  "--check-links-ignore=https://earthobservatory.nasa.gov/images/148414/lake-victorias-rising-waters"
+  "--check-links-ignore=https://earthobservatory.nasa.gov/images/148414/lake-victorias-rising-waters",
+  "--check-links-ignore=https://timesofmalta.com/article/february-marks-9th-straight-month-recordsmashing-global-heat.1087990"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Hi @burggraaff,

The weekly run flagged a 403 in your notebooks:

https://timesofmalta.com/article/february-marks-9th-straight-month-recordsmashing-global-heat.1087990

I think it's safe to ignore this one, as their website requires consent before the article can be accessed.

We should also cache 403 responses, as they're unlikely to change within 24 hours.

The new workflow seems to be working well. It only flagged two additional issues in the notebooks for our contract. One is a real issue, as the NASA website is currently experiencing problems, while the other may just be a flaky website. I'll monitor it for a couple of weeks, and if it doesn't stabilize, I'll exclude it.