### PR TITLE
revise qa

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+    - run: git fetch origin main
     - uses: actions/setup-python@v7
       with:
         python-version: '3.x'

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -20,33 +20,19 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  pre-commit-general:
+  qa:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
     - uses: actions/setup-python@v7
       with:
         python-version: '3.x'
-    - uses: pre-commit/action@v3.0.1
-      env:
-        SKIP: validate-filenames,check-notebook-links,validate-dois
-
-  pre-commit-modified-only:
-    runs-on: ubuntu-latest
-    needs: pre-commit-general
-    strategy:
-      matrix:
-        hook: [validate-filenames, check-notebook-links, validate-dois]
-    steps:
-    - uses: actions/checkout@v7
-    - run: git fetch origin main
-    - uses: actions/setup-python@v7
-      with:
-        python-version: '3.x'
-    - name: Run ${{ matrix.hook }} on modified files
+    - name: QA on all files
+      uses: pre-commit/action@v3.0.1
+    - name: Manual QA on modified files
       uses: pre-commit/action@v3.0.1
       with:
-        extra_args: --from-ref origin/main --to-ref HEAD ${{ matrix.hook }}
+        extra_args: --hook-stage manual --from-ref origin/main --to-ref HEAD
 
   deploy-preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -32,4 +32,5 @@ jobs:
         title: pre-commit autoupdate
     - uses: pre-commit/action@v3.0.1
       timeout-minutes: 60
-
+      with:
+        extra_args: --hook-stage manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,7 @@ repos:
     types: [jupyter]
     exclude: ^(templates/|Applications/)
     additional_dependencies: [requests, requests-cache]
+    stages: [manual]
 - repo: local
   hooks:
   - id: check-notebook-links
@@ -85,6 +86,7 @@ repos:
     types_or: [jupyter, markdown]
     additional_dependencies: ["pytest-check-links[cache]", "requests>=2.34.2"]
     require_serial: true
+    stages: [manual]
 - repo: local
   hooks:
   - id: validate-dois
@@ -94,3 +96,4 @@ repos:
     types: [jupyter]
     additional_dependencies: [nbformat, requests, requests-cache]
     require_serial: true
+    stages: [manual]

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ help: ## Show this help menu
 
 qa: ## Run code quality tools
 	pre-commit run --all-files
+	pre-commit run --hook-stage manual --from-ref origin/main --to-ref HEAD
+
+qa-all: ## Run code quality tools on all files
+	pre-commit run --all-files --hook-stage manual
 
 clean-book: ## Remove temporary build directory
 	rm -fr $(PRE_BUILD_DIR)


### PR DESCRIPTION
Hi @burggraaff ,

Yes, the behaviour you described in https://github.com/ecmwf-projects/c3s2-eqc-quality-assessment/pull/642#issuecomment-5136706166 was intended.

Let's see if we can find something that suits you better. I'm trying to reduce the number of configuration files we have, as well as the duplication between local configuration and GitHub workflows. We might want to do a more substantial refactor and switch to different tools or actions in the future, but for now we're in maintenance mode only.

How about this?

- `make qa` runs hooks on all fast files, then runs all hooks, including the slow ones, on touched files only.
- `make qa-all` is equivalent to the weekly runs.